### PR TITLE
Fix make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
-echo "Welcome To Scribe Builder"
-echo "Building 'main.cpp' with arguments -lsfml-graphics -lsfml-window -lsfml-system"
-g++ installer.cpp -o scribe -lsfml-graphics -lsfml-window -lsfml-system
+echo "This sh script will build ShareCC"
+echo "Building 'installer.cpp' with arguments -lsfml-graphics -lsfml-window -lsfml-system"
+g++ installer.cpp -o ShareCC -lsfml-graphics -lsfml-window -lsfml-system
 echo "Done compiling! Now running."
-./scribe
+./ShareCC
 echo "Scribe has terminated! If you closed the program yourself, this is fine. But if this happened shortly after the last message, there may be an error in your code."


### PR DESCRIPTION
"make.sh" was outputting to an incorrect filename, "scribe". This has been fixed in this patch.